### PR TITLE
Use webpack's url-loader to bundle images

### DIFF
--- a/app/package.json
+++ b/app/package.json
@@ -51,6 +51,7 @@
     "sass-loader": "^3.1.2",
     "style-loader": "^0.13.0",
     "underscore": "^1.8.3",
+    "url-loader": "^0.5.7",
     "webpack": "^1.12.14",
     "webpack-dev-server": "^1.14.1"
   },

--- a/app/src/components/ChangedItem/index.js
+++ b/app/src/components/ChangedItem/index.js
@@ -4,15 +4,18 @@ import { FormattedNumber } from 'react-intl';
 
 import styles from './styles.scss';
 
+import upArrowIcon from 'images/icons/upArrow.gif';
+import downArrowIcon from 'images/icons/downArrow.gif';
+
 class ChangedItem extends Component {
   render() {
     const { name, change } = this.props.dept;
-    const icon = change > 0 ? 'upArrow' : 'downArrow';
+    const icon = change > 0 ? upArrowIcon : downArrowIcon;
 
     return (
       <p>
         <img
-          src={`../../src/images/icons/${icon}.gif`}
+          src={icon}
           alt="arrow"
           style={{ width: '15px' }}
         />

--- a/app/src/components/NavBottom/index.js
+++ b/app/src/components/NavBottom/index.js
@@ -3,24 +3,29 @@ import { Link } from 'react-router';
 
 import styles from './styles.scss';
 
+import homeImage from 'images/icons/bottom-nav/home.svg';
+import revenueImage from 'images/icons/bottom-nav/revenue.svg';
+import servicesImage from 'images/icons/bottom-nav/services.svg';
+import reportImage from 'images/icons/bottom-nav/report.svg';
+
 class NavBottom extends Component {
   render() {
     return (
       <div className={styles.navBottom}>
         <Link to="/" className={styles.navItem}>
-          <img className={styles.navIcon} src="../../src/images/icons/bottom-nav/home.svg" alt=""/>
+          <img className={styles.navIcon} src={homeImage} alt=""/>
           <span className={styles.navText}>Home</span>
         </Link>
         <Link to="/fund" className={styles.navItem}>
-          <img className={styles.navIcon} src="../../src/images/icons/bottom-nav/revenue.svg" alt=""/>
+          <img className={styles.navIcon} src={revenueImage} alt=""/>
           <span className={styles.navText}>Fund</span>
         </Link>
         <Link to="/services" className={styles.navItem}>
-          <img className={styles.navIcon} src="../../src/images/icons/bottom-nav/services.svg" alt=""/>
+          <img className={styles.navIcon} src={servicesImage} alt=""/>
           <span className={styles.navText}>Services</span>
         </Link>
         <Link to="/report" className={styles.navItem}>
-          <img className={styles.navIcon} src="../../src/images/icons/bottom-nav/report.svg" alt=""/>
+          <img className={styles.navIcon} src={reportImage} alt=""/>
           <span className={styles.navText}>Report</span>
         </Link>
       </div>

--- a/app/src/components/SaveAndSubmitCard/index.js
+++ b/app/src/components/SaveAndSubmitCard/index.js
@@ -3,6 +3,7 @@ import firebase from 'firebase';
 import ReactFireMixin from 'reactfire';
 
 import styles from './styles.scss';
+import saveAndSubmitImage from 'images/icons/saveAndSubmit.gif';
 
 const config = {
   apiKey: "AIzaSyDVYXW7KD054GkOAzHb597yrEZMMxz0aDM",
@@ -67,7 +68,7 @@ const SaveAndSubmitCard = React.createClass({
       <div className={styles.cardOutline}>
         <div className={styles.cardHeader}>
           <img
-            src="../../src/images/icons/saveAndSubmit.gif"
+            src={saveAndSubmitImage}
             alt="Envelope Icon"
             className={styles.icon}
           />

--- a/app/src/components/YourBudgetCard/index.js
+++ b/app/src/components/YourBudgetCard/index.js
@@ -2,6 +2,8 @@ import React, { Component, PropTypes } from 'react';
 import { FormattedNumber } from 'react-intl';
 
 import styles from './styles.scss';
+import yourBudgetIcon from 'images/icons/YourBudget.gif';
+
 
 class YourBudgetCard extends Component {
   render() {
@@ -13,7 +15,7 @@ class YourBudgetCard extends Component {
     return (
       <div className={styles.cardOutline}>
         <div className={styles.cardHeader}>
-          <img src="../../src/images/icons/YourBudget.gif"
+          <img src={yourBudgetIcon}
             className={styles.icon}
             alt="Your Budget Results icon"
           />

--- a/app/src/data/services.js
+++ b/app/src/data/services.js
@@ -1,3 +1,8 @@
+import publicSafetyImage from 'images/icons/publicSafety.gif';
+import developmentImage from 'images/icons/development.gif';
+import communityServicesImage from 'images/icons/services.gif';
+import infraTransportImage from 'images/icons/infraTransport.gif';
+
 const servicesData = {
   generalFund: 969200000,
   generalFund2016: 911000000,
@@ -6,7 +11,7 @@ const servicesData = {
     {
       name: 'Public Safety',
       url: 'public-safety',
-      image: '../../src/images/icons/publicSafety.gif',
+      image: publicSafetyImage,
       description: "Public safety made up nearly 70% of the City's General Fund budget, providing for police, fire, EMS and municipal court services.",
       groupdId: 1,
       departments: [1, 2, 3, 4],
@@ -14,7 +19,7 @@ const servicesData = {
     {
       name: 'Development',
       url: 'development',
-      image: '../../src/images/icons/development.gif',
+      image: developmentImage,
       description: 'The City’s development departments oversee the city’s planning, zoning, and permitting, and inspection services.',
       groupId: 2,
       departments: [5, 6],
@@ -22,7 +27,7 @@ const servicesData = {
     {
       name: 'Community Services',
       url: 'community-services',
-      image: '../../src/images/icons/services.gif',
+      image: communityServicesImage,
       description: 'The departments housed under community services provide environmental health services, animal services, and family health services, and managing the City’s libraries, parks, and affordable housing programs.',
       groupdId: 3,
       departments: [7, 8, 9, 10, 11, 12],
@@ -30,7 +35,7 @@ const servicesData = {
     {
       name: 'Infrastructure & Mobility',
       url: 'infra-transportation',
-      image: '../../src/images/icons/infraTransport.gif',
+      image: infraTransportImage,
       description: '',
       groupdId: 4,
       departments: [13, 14],

--- a/app/webpack.config.js
+++ b/app/webpack.config.js
@@ -29,6 +29,10 @@ module.exports = {
           'sass',
         ],
       },
+      {
+        test: /\.(gif|png|svg)$/,
+        loader: 'url-loader?limit=32768',
+      },
     ],
   },
   postcss: [

--- a/app/webpack.production.config.js
+++ b/app/webpack.production.config.js
@@ -23,6 +23,10 @@ module.exports = {
         test: /\.scss$/,
         loader: ExtractTextPlugin.extract('style', 'css?modules&importLoaders=1&localIdentName=[name]__[local]___[hash:base64:5]!postcss-loader!sass'),
       },
+      {
+        test: /\.(gif|png|svg)$/,
+        loader: 'url-loader?limit=32768',
+      },
     ],
   },
   sassLoader: {


### PR DESCRIPTION
This uses the webpack url-loader to take image files and transform them
into url-encoded strings when `import`ed. This makes the images part of
the app's javascript bundle which results in a larger bundle, but now
there will be no need for the server to host separate files and images
will load immediately (no need to request and wait for images over the
network).

Addresses #47 